### PR TITLE
Fix memory leaks, race conditions, make opening an IPv6/IPv4 socket optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,16 @@ class PingHandler : PingResponseHandler {
       System.out.printf("  ${Thread.currentThread()} $byteCount bytes from $pingTarget: icmp_seq=$seq time=%1.6f\n", responseTimeSec)
    }
 
-   override fun onTimeout(pingTarget: PingTarget) {
-      System.out.println("  ${Thread.currentThread()} Timeout $pingTarget")
+   override fun onFailure(pingTarget : PingTarget, failureReason: FailureReason) {
+      System.out.println("  ${Thread.currentThread()} Ping failed: $failureReason")
    }
 }
 
 val pinger = IcmpPinger(PingHandler())
 
-Thread( { pinger.runSelector() } ).start()
+Thread { pinger.runSelector() }.start()
+
+Thread.sleep(100)
 
 pinger.ping( PingTarget(InetAddress.getByName("8.8.8.8")) )
 pinger.ping( PingTarget(InetAddress.getByName("youtube.com")) )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 var group = "com.zaxxer"
-var version = "2.0.1"
+var version = "2.1.0"
 var description = "Java Non-Blocking Ping (ICMP)"
 
 project.group = group

--- a/src/main/kotlin/com/zaxxer/ping/IcmpPinger.kt
+++ b/src/main/kotlin/com/zaxxer/ping/IcmpPinger.kt
@@ -241,9 +241,11 @@ class IcmpPinger(private val responseHandler:PingResponseHandler) {
                }
             }
 
-            awoken.compareAndSet(true, false)
-
-            if (fdPipe.revents and POLLIN_OR_PRI != 0) wakeupReceived()
+            val wokeUp = fdPipe.revents and POLLIN_OR_PRI != 0
+            if (wokeUp) {
+               wakeupReceived()
+               awoken.compareAndSet(true, false)
+            }
 
             if (rc > 0) {
                if (fd4.revents and POLLERR != 0 || fd6.revents and POLLERR != 0) {

--- a/src/main/kotlin/com/zaxxer/ping/IcmpPinger.kt
+++ b/src/main/kotlin/com/zaxxer/ping/IcmpPinger.kt
@@ -103,7 +103,7 @@ class PingTarget : Comparable<PingTarget> {
       this.timeoutMs = pingTarget.timeoutMs
       this.sockAddr = pingTarget.sockAddr
       this.isIPv4 = pingTarget.isIPv4
-      this.id = (ID_SEQUENCE.getAndIncrement() % 0xffff).toShort()
+      this.id = (ID_SEQUENCE.getAndIncrement() and 0xffff).toShort()
    }
 
    internal fun timestamp() {
@@ -323,7 +323,7 @@ class IcmpPinger(private val responseHandler:PingResponseHandler) {
    private fun sendIcmp(pingTarget: PingTarget, fd: FD) : Boolean {
       prebuiltBufferPointer.transferTo(0, socketBufferPointer, 0, BUFFER_SIZE)
 
-      pingTarget.sequence = (SEQUENCE_SEQUENCE.getAndIncrement() % 0xffff).toShort()
+      pingTarget.sequence = (SEQUENCE_SEQUENCE.getAndIncrement() and 0xffff).toShort()
 
       if (pingTarget.isIPv4) {
          icmp.useMemory(outpacketPointer)

--- a/src/main/kotlin/com/zaxxer/ping/IcmpPinger.kt
+++ b/src/main/kotlin/com/zaxxer/ping/IcmpPinger.kt
@@ -203,8 +203,11 @@ class IcmpPinger(private val responseHandler:PingResponseHandler) {
       while (running) {
          val rc = libc.poll(fdBufferPointer, FDS, pollTimeoutMs)
          if (rc < 0) {
-            LOGGER.severe {"poll() returned errno ${posix.errno()}"}
-            break
+            val errno = posix.errno()
+            if (errno != Errno.EINTR.intValue()) {
+               LOGGER.severe("poll() returned errno $errno")
+               break
+            }
          }
 
          awoken.compareAndSet(true, false)

--- a/src/main/kotlin/com/zaxxer/ping/IcmpPinger.kt
+++ b/src/main/kotlin/com/zaxxer/ping/IcmpPinger.kt
@@ -265,8 +265,8 @@ class IcmpPinger(private val responseHandler:PingResponseHandler) {
                if (fd4.fd > 0 && fd4.revents and POLLIN_OR_PRI != 0) processReceives(fd4.fd, true)
                if (fd6.fd > 0 && fd6.revents and POLLIN_OR_PRI != 0) processReceives(fd6.fd, false)
 
-               if (fd4.revents and POLLOUT != 0) processSends(pending4Pings, waitingTargets4, fd4, true)
-               if (fd6.revents and POLLOUT != 0) processSends(pending6Pings, waitingTargets6, fd6, false)
+               if (wokeUp || fd4.revents and POLLOUT != 0) processSends(pending4Pings, waitingTargets4, fd4, true)
+               if (wokeUp || fd6.revents and POLLOUT != 0) processSends(pending6Pings, waitingTargets6, fd6, false)
 
                fdPipe.revents = 0
                fd4.revents = 0

--- a/src/main/kotlin/com/zaxxer/ping/IcmpPinger.kt
+++ b/src/main/kotlin/com/zaxxer/ping/IcmpPinger.kt
@@ -112,7 +112,12 @@ class PingTarget : Comparable<PingTarget> {
       complete = false
    }
 
-    override fun compareTo(other: PingTarget): Int = timeout.compareTo(other.timeout)
+    override fun compareTo(other: PingTarget): Int {
+       val timeoutDelta = timeout.compareTo(other.timeout)
+       if (timeoutDelta != 0)
+          return timeoutDelta
+       return sequence.compareTo(other.sequence)
+    }
 
    override fun toString(): String = inetAddress.toString()
 }

--- a/src/main/kotlin/com/zaxxer/ping/IcmpPinger.kt
+++ b/src/main/kotlin/com/zaxxer/ping/IcmpPinger.kt
@@ -196,9 +196,6 @@ class IcmpPinger(private val responseHandler:PingResponseHandler) {
       val infinite:Int = -1
       var pollTimeoutMs:Int = infinite
 
-      val logPendingPings: () -> String = {"   Pending ping count ${pending4Pings.size + pending6Pings.size}"}
-      val logPendingActor: () -> String = {"   Pending actor count ${waitingTargets4.size + waitingTargets6.size}"}
-
       var noopLoops = 0
       while (running) {
          val rc = libc.poll(fdBufferPointer, FDS, pollTimeoutMs)
@@ -216,7 +213,7 @@ class IcmpPinger(private val responseHandler:PingResponseHandler) {
 
          if (rc > 0) {
             if (fd4.revents and POLLERR != 0 || fd6.revents and POLLERR != 0) {
-               LOGGER.severe {"poll() created a POLLERR event"}
+               LOGGER.severe("poll() created a POLLERR event")
                break
             }
 
@@ -237,8 +234,7 @@ class IcmpPinger(private val responseHandler:PingResponseHandler) {
 
          pollTimeoutMs = maxOf(MICROSECONDS.toMillis(nextTimeoutUsec), 1L).toInt()
 
-         LOGGER.fine(logPendingPings)
-         LOGGER.fine(logPendingActor)
+         LOGGER.fine(::logPendingPingsAndActors)
 
          val isPending4reads = waitingTargets4.isNotEmpty()
          val isPending6reads = waitingTargets6.isNotEmpty()
@@ -462,6 +458,10 @@ class IcmpPinger(private val responseHandler:PingResponseHandler) {
       fd4.fd = 0
       fd6.fd = 0
    }
+
+   private fun logPendingPingsAndActors(): String =
+      "   Pending ping count ${pending4Pings.size + pending6Pings.size}\n" +
+      "   Pending actor count ${waitingTargets4.size + waitingTargets6.size}"
 }
 
 private fun setNonBlocking(fd: FD) {

--- a/src/main/kotlin/com/zaxxer/ping/impl/util/HexDumpElf.kt
+++ b/src/main/kotlin/com/zaxxer/ping/impl/util/HexDumpElf.kt
@@ -30,7 +30,7 @@ internal fun dumpBuffer(message:String, buffer:ByteBuffer, offset:Int = 0) : Str
 
    return StringBuilder()
          .append("   $message\n")
-         .append(dump(0, bytes, 0, bytes.size))
+         .append(dump(0, bytes))
          .toString()
 }
 
@@ -45,7 +45,7 @@ internal fun dumpBuffer(message:String, buffer:ByteBuffer, offset:Int = 0) : Str
  * @param len the length of data to dump
  * @return the dump string
  */
-fun dump(displayOffset:Int, data:ByteArray, offset:Int, len:Int) : String {
+fun dump(displayOffset:Int, data:ByteArray, offset:Int = 0, len:Int = data.size) : String {
    val sb = StringBuilder()
    val formatter = Formatter(sb)
    val ascii = StringBuilder()

--- a/src/main/kotlin/com/zaxxer/ping/impl/util/WaitingTargetCollection.kt
+++ b/src/main/kotlin/com/zaxxer/ping/impl/util/WaitingTargetCollection.kt
@@ -33,8 +33,7 @@ class WaitingTargetCollection {
                 waitingTargetMap.remove(pingTarget.sequence)
                 continue
             }
-            else
-                return pingTarget.timeout
+            return pingTarget.timeoutNs
         } while (true)
     }
 
@@ -57,9 +56,5 @@ class WaitingTargetCollection {
         return pingTarget
     }
 
-    fun size() = waitingTargetMap.size()
-
     fun isNotEmpty() = !waitingTargetMap.isEmpty
-
-    fun isEmpty() = waitingTargetMap.isEmpty
 }

--- a/src/test/kotlin/com/zaxxer/ping/PingTest.kt
+++ b/src/test/kotlin/com/zaxxer/ping/PingTest.kt
@@ -261,10 +261,10 @@ class PingTest {
       selectorThread.isDaemon = false
       selectorThread.start()
 
+      MILLISECONDS.sleep(100L)
+
       // Ping a non existing ip address
       pinger.ping(PingTarget(InetAddress.getByName("240.0.0.0")))
-
-      MILLISECONDS.sleep(100L)
 
       while (pinger.isPendingWork()) Thread.sleep(500L)
 

--- a/src/test/kotlin/com/zaxxer/ping/PingTest.kt
+++ b/src/test/kotlin/com/zaxxer/ping/PingTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
+import org.junit.jupiter.api.Timeout
 import java.io.IOException
 import java.net.Inet6Address
 import java.net.InetAddress
@@ -87,6 +88,7 @@ class PingTest {
    }
 
    @Test
+   @Timeout(60)
    @Throws(IOException::class)
    fun pingTest1() {
       val semaphore = Semaphore(2)
@@ -136,6 +138,7 @@ class PingTest {
    }
 
    //
+   @Timeout(60)
    @Throws(IOException::class)
    fun pingTestIpv6() {
       val semaphore = Semaphore(2)
@@ -181,6 +184,7 @@ class PingTest {
       assertTrue(timeoutTargets.isEmpty(), "$timeoutTargets timed out.")
 
    @Test
+   @Timeout(60)
    fun testTimeoutOrder() {
       val pings = 512
       val semaphore = Semaphore(pings)
@@ -228,6 +232,7 @@ class PingTest {
    }
 
    @Test
+   @Timeout(60)
    @Throws(IOException::class)
    fun testPingFailure() {
 
@@ -264,6 +269,7 @@ class PingTest {
    }
 
    @Test
+   @Timeout(60)
    fun testSimultaneousRequest() {
       val pingCount = 2
 


### PR DESCRIPTION
Hello again @brettwooldridge!

Some of our clients run hardened versions of Linux that don't allow creation or use of IPv6 sockets in any capacity. Thinking of how to tackle this problem I thought it would be better to make JNB-Ping open sockets lazily. If clients don't ping any IPv6 addresses, there's no need to open an IPv6 socket. I also thought it would be better to let library users decide how to handle the fact that we couldn't open an IPv6 or IPv4 socket.

While fixing this issue, the control flow started to get a little bit more tangled up so I decided to change a few things to hopefully make things clearer in terms of execution order.

### Here's a list of changes made:

1. Sockets are opened lazily when the first ICMP request of an IP family is made. Library users decide how to treat unsent pings or failures to open a socket. https://github.com/brettwooldridge/jnb-ping/commit/f62f2ec5af7d0a1627e700242ffdd5ba2dfb815f
2. `runSelector` can now be called repeatedly without stalling or requiring to recreate the `IcmpPinger` object. https://github.com/brettwooldridge/jnb-ping/commit/5965fd6bc0b7a0ee86248df7165358fdc732b793
3. Fixed memory leaks. Some user objects do get quite heavy. https://github.com/brettwooldridge/jnb-ping/commit/ebfbd551efc08433245472638ec6e90f97c9d4b3, https://github.com/brettwooldridge/jnb-ping/commit/fe9b57998398dedc46b9f9473b3cc83fffa05ba4
4. Don't close unused FD's after multiple NOOP rounds. It seems like more trouble than it's worth to support this feature without making code more convoluted. I asked our tech-support. They've never had any bug reports regarding file-descriptor depletion except the one we fixed last time. https://github.com/brettwooldridge/jnb-ping/commit/f62f2ec5af7d0a1627e700242ffdd5ba2dfb815f, https://github.com/brettwooldridge/jnb-ping/commit/d548ab4a3071a66be20a63cabedae8ce99ef1ffb
5. Calling `onFailure` for every queued ping, even if it was queued when `runSelector` is not yet running or is no longer running. https://github.com/brettwooldridge/jnb-ping/commit/8213eb430de81778473641641e8db4cfd0716862
6. Fixing some race conditions. https://github.com/brettwooldridge/jnb-ping/commit/5f4da0d2c7144191c69930363f547362630cd72e
7. Throwing exceptions in `onResponse` / `onFailure` won't lead to leaks or stop the selector.
8. The rest are minor bug fixes or refactors.

If you think some things should be a little different, please say so.